### PR TITLE
Fix #1 - add unveil(2) support

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -4,7 +4,7 @@ packages:
 sources:
 - https://github.com/euantorano/pledge.nim
 environment:
-  NIM_VERSION: 0.20.2
+  NIM_VERSION: 1.0.0
   CC: /usr/bin/clang
 tasks:
 - install_nim: |

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -4,7 +4,7 @@ packages:
 sources:
 - https://github.com/euantorano/pledge.nim
 environment:
-  NIM_VERSION: 1.0.0
+  NIM_VERSION: 0.20.2
   CC: /usr/bin/clang
 tasks:
 - install_nim: |
@@ -21,5 +21,5 @@ tasks:
     env PATH="$HOME/nim-${NIM_VERSION}/bin:$PATH" nim c --cc:clang -r tests/main.nim
 triggers:
 - action: email
-  condition: failure
+  condition: always
   to: Euan T <euan+pledge.nim@torano.co.uk>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pledge.nim [![builds.sr.ht status](https://builds.sr.ht/~euantorano.svg?search=pledge.nim)](https://builds.sr.ht/~euantorano?search=pledge.nim)
 
-A wrapper around OpenBSD's `pledge(2)` systemcall for Nim.
+A wrapper around OpenBSD's `pledge(2)` system call for Nim.
+
+Includes support for OpenBSD's `unveil(2)` system call.
 
 ## Installation
 
@@ -15,7 +17,7 @@ Or add the following to your `.nimble` file:
 ```
 # Dependencies
 
-requires "pledge >= 1.1.0"
+requires "pledge >= 2.0.0"
 ```
 
 ## [Documentation](https://htmlpreview.github.io/?https://github.com/euantorano/pledge.nim/blob/master/docs/pledge.html)
@@ -27,6 +29,6 @@ import pledge
 
 pledge(Promises.Stdio)
 
-# As we haven't used pledge to ask to access files, the below will cause the program to be temrinated with a SIGABRT.
+# As we haven't used pledge to ask to access files, the below will cause the program to be terminated with a SIGABRT.
 let f = open("/etc/rc.conf")
 ```

--- a/docs/pledge.html
+++ b/docs/pledge.html
@@ -836,6 +836,9 @@ function main() {
   Recvfd = &quot;recvfd&quot;, Tape = &quot;tape&quot;, Tty = &quot;tty&quot;, Proc = &quot;proc&quot;, Exec = &quot;exec&quot;,
   ProtExec = &quot;prot_exec&quot;, Settime = &quot;settime&quot;, Ps = &quot;ps&quot;, Vminfo = &quot;vminfo&quot;, Id = &quot;id&quot;,
   Pf = &quot;pf&quot;, Audio = &quot;audio&quot;, Video = &quot;video&quot;, Bpf = &quot;bpf&quot;, Unveil = &quot;unveil&quot;, Error = &quot;error&quot;"><wbr />Promise<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#Permission"
+    title="Permission {.pure.} = enum
+  CreateRemove = &apos;c&apos;, Read = &apos;r&apos;, Write = &apos;w&apos;, Execute = &apos;x&apos;"><wbr />Permission<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -844,6 +847,8 @@ function main() {
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#pledge%2COption%5Bstring%5D%2COption%5Bstring%5D"
     title="pledge(promises: Option[string]; execPromises: Option[string] = none(string))"><wbr />pledge<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#unveil%2COption%5Bstring%5D%2COption%5Bstring%5D"
+    title="unveil(path: Option[string]; permissions: Option[string])"><wbr />unveil<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -852,6 +857,8 @@ function main() {
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#pledge.t%2Cvarargs%5BPromise%5D"
     title="pledge(promises: varargs[Promise])"><wbr />pledge<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#unveil.t%2Cstring%2Cset%5BPermission%5D"
+    title="unveil(path: string; permissions: set[Permission])"><wbr />unveil<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -889,6 +896,14 @@ function main() {
 The possible operation sets that a program can pledge to be limited to.
 
 </dd>
+<a id="Permission"></a>
+<dt><pre><a href="pledge.html#Permission"><span class="Identifier">Permission</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">pure</span></span><span class="Other">.}</span></span> <span class="Other">=</span> <span class="Keyword">enum</span>
+  <span class="Identifier">CreateRemove</span> <span class="Other">=</span> <span class="CharLit">'c'</span><span class="Other">,</span> <span class="Identifier">Read</span> <span class="Other">=</span> <span class="CharLit">'r'</span><span class="Other">,</span> <span class="Identifier">Write</span> <span class="Other">=</span> <span class="CharLit">'w'</span><span class="Other">,</span> <span class="Identifier">Execute</span> <span class="Other">=</span> <span class="CharLit">'x'</span></pre></dt>
+<dd>
+
+The possible permissions that a call to <tt class="docutils literal"><span class="pre">unveil</span></tt> can be used with.
+
+</dd>
 
 </dl></div>
 <div class="section" id="12">
@@ -902,6 +917,13 @@ The possible operation sets that a program can pledge to be limited to.
 <p>Pledge to use only the defined functions.</p>
 <p>If no promises are provided, the process will be restricted to the <tt class="docutils literal"><span class="pre">_exit(2)</span></tt> system call.</p>
 
+
+</dd>
+<a id="unveil,Option[string],Option[string]"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#unveil%2COption%5Bstring%5D%2COption%5Bstring%5D"><span class="Identifier">unveil</span></a><span class="Other">(</span><span class="Identifier">path</span><span class="Other">:</span> <span class="Identifier">Option</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">]</span><span class="Other">;</span> <span class="Identifier">permissions</span><span class="Other">:</span> <span class="Identifier">Option</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">]</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Unveil parts of a restricted filesystem view.
 
 </dd>
 
@@ -918,6 +940,13 @@ The possible operation sets that a program can pledge to be limited to.
 
 
 </dd>
+<a id="unveil.t,string,set[Permission]"></a>
+<dt><pre><span class="Keyword">template</span> <a href="#unveil.t%2Cstring%2Cset%5BPermission%5D"><span class="Identifier">unveil</span></a><span class="Other">(</span><span class="Identifier">path</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">permissions</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><a href="pledge.html#Permission"><span class="Identifier">Permission</span></a><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+Unveil parts of a restricted filesystem view.
+
+</dd>
 
 </dl></div>
 
@@ -928,7 +957,7 @@ The possible operation sets that a program can pledge to be limited to.
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small>Made with Nim. Generated: 2019-08-20 12:07:44 UTC</small>
+        <small>Made with Nim. Generated: 2019-09-30 19:55:46 UTC</small>
       </div>
     </div>
   </div>

--- a/docs/pledge.idx
+++ b/docs/pledge.idx
@@ -1,5 +1,8 @@
 Example of making a single promise	pledge.html#example-of-making-a-single-promise	 Example of making a single promise	
 Example of making several promises	pledge.html#example-of-making-several-promises	 Example of making several promises	
 Promise	pledge.html#Promise	pledge: Promise	
+Permission	pledge.html#Permission	pledge: Permission	
 pledge	pledge.html#pledge,Option[string],Option[string]	pledge: pledge(promises: Option[string]; execPromises: Option[string] = none(string))	
+unveil	pledge.html#unveil,Option[string],Option[string]	pledge: unveil(path: Option[string]; permissions: Option[string])	
 pledge	pledge.html#pledge.t,varargs[Promise]	pledge: pledge(promises: varargs[Promise])	
+unveil	pledge.html#unveil.t,string,set[Permission]	pledge: unveil(path: string; permissions: set[Permission])	

--- a/pledge.nimble
+++ b/pledge.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.1.1"
+version       = "2.0.0"
 author        = "Euan T"
 description   = "A wrapper around OpenBSD's pledge(2) systemcall for Nim."
 license       = "BSD3"
@@ -9,7 +9,7 @@ srcDir = "src"
 
 # Dependencies
 
-requires "nim >= 0.13.0"
+requires "nim >= 1.0.0"
 
 task docs, "Build documentation":
   exec "nim doc2 --index:on -o:docs/pledge.html src/pledge.nim"

--- a/src/pledge.nim
+++ b/src/pledge.nim
@@ -126,11 +126,11 @@ elif defined(openbsd):
 
   proc unveil*(path: Option[string], permissions: Option[string]) =
     ## Unveil parts of a restricted filesystem view.
-    if (osVersion.major == 6 and osVerison.minor < 4) or osVersion.major < 6:
+    if (osVersion.major == 6 and osVersion.minor < 4) or osVersion.major < 6:
       raise newException(UnveilNotAvailableException, &"unveil(2) system call is not available on OpenBSD {osVersion.major}.{osVersion.minor}")
 
     let pathValue: cstring = if path.isSome(): cstring(path.get()) else: nil
-    let permissionsValue: cstring = if permissions.isSome(): cstrimg(permissions.get()) else: nil
+    let permissionsValue: cstring = if permissions.isSome(): cstring(permissions.get()) else: nil
 
     if unveil_c(pathValue, permissionsValue) != 0:
       raiseOSError(osLastError())

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -1,18 +1,5 @@
 import pledge, unittest, os
 
-suite "pledge tests":
-  test "can pledge":
-    pledge(Promise.Stdio, Promise.Rpath)
-
-    check true
-
-  when defined(openbsd):
-    test "can not elevate":
-      pledge(Promise.Stdio)
-
-      expect OSError:
-        pledge(Promise.Stdio, Promise.Rpath)
-
 suite "unveil tests":
   test "can access path that is unveiled":
     unveil("/dev/urandom", {Permission.Read})
@@ -25,7 +12,20 @@ suite "unveil tests":
   when defined(openbsd):
     test "can't access path that isn't unveiled":
       unveil("/dev/urandom", {Permission.Read})
+      unveil("", {})
+
+      var f: File
+      check not open(f, "/dev/zero", fmRead)
+
+suite "pledge tests":
+  test "can pledge":
+    pledge(Promise.Stdio, Promise.Rpath, Promise.Unveil)
+
+    check true
+
+  when defined(openbsd):
+    test "can not elevate":
+      pledge(Promise.Stdio, Promise.Unveil)
 
       expect OSError:
-        var f: File
-        open(f, "/dev/zero", fmRead)
+        pledge(Promise.Stdio, Promise.Rpath, Promise.Unveil)

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -28,4 +28,4 @@ suite "unveil tests":
 
       expect OSError:
         var f: File
-        check open(f, "/dev/zero", fmRead)
+        open(f, "/dev/zero", fmRead)

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -12,3 +12,20 @@ suite "pledge tests":
 
       expect OSError:
         pledge(Promise.Stdio, Promise.Rpath)
+
+suite "unveil tests":
+  test "can access path that is unveiled":
+    unveil("/dev/urandom", {Permission.Read})
+
+    var f: File
+    check open(f, "/dev/urandom", fmRead)
+    var buff: array[0..9, byte]
+    check f.readBytes(buff, 0, len(buff)) > 0
+
+  when defined(openbsd):
+    test "can't access path that isn't unveiled":
+      unveil("/dev/urandom", {Permission.Read})
+
+      expect OSError:
+        var f: File
+        check open(f, "/dev/zero", fmRead)


### PR DESCRIPTION
Fixes #2 - adds support for the `unveil(2)` system call which can be used as follows:

```nim
unveil("/foo/bar", {Permission.Read, Permission.Write, Permission.Execute})
```

Passing an empty string and an empty set of promises is the same as `unveil(NULL, NULL)` in C, disabling future calls to `unveil`:

```nim
unveil("", {})
```