### PR TITLE
Fix pledge value when option is none

### DIFF
--- a/src/pledge.nim
+++ b/src/pledge.nim
@@ -114,7 +114,7 @@ elif defined(openbsd):
     if (osVersion.major < 6 or (osVersion.major == 6 and osVersion.minor <= 2)) and execPromises.isSome():
       raise newException(PledgeExecPromisesNotAvailableError, &"cannot use execpromises with pledge(2) on OpenBSD {osVersion.major}.{osVersion.minor}")
 
-    let promisesValue: cstring = if promises.isSome(): cstring(promises.get()) else: nil
+    let promisesValue: cstring = if promises.isSome(): cstring(promises.get()) else: ""
     var execPromisesValue: cstring = nil
 
     # if running on openBSD <= 6.2, execpromises should be passed as NULL


### PR DESCRIPTION
Calling `pledge()` has no effect.

I believe the equivalent cstring value when no promise is supplied, should be the empty string and not nil (otherwise nothing is restricted).

According to the manual:

    A promises value of "" restricts the process to the _exit(2) system call. 
    This can be used for pure computation operating on memory shared with another process.